### PR TITLE
few minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@ mgo-statsd
 ==========
 
 Small go process which polls mongodb for server status shipping as metrics to statsd
+
+
+## Compiling
+
+Make sure `golang` is installed and `GOPATH` is defined in your environment.
+
+Then run `./build.sh`.
+
+## Usage
+
+The simplest form is just to run it this way and it will attempt to connect via
+unauthorized fashion to a mongodb instance on localhost.
+
+```
+./mgo-statsd  -statsd_host="statsd.hostname"
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Is go installed?
+go_is_not_installed=`which go`
+: ${go_is_not_installed:?"go binary not found. Is Golang installed?"}
+
+# check for GOPATH and fail if not there
+: ${GOPATH:?"GOPATH not defined"}
+
+# install the deps.  should use a build tool...
+go get github.com/cactus/go-statsd-client/statsd
+go get github.com/vharitonsky/iniflags
+go get gopkg.in/mgo.v2
+
+# now build it
+go build

--- a/main.go
+++ b/main.go
@@ -246,7 +246,11 @@ func pushExtraInfo(client statsd.Statter, info ExtraInfo) error {
 }
 
 func pushStats(statsd_config Statsd, status ServerStatus) error {
-	prefix := fmt.Sprintf("%s.%s.%s", statsd_config.Env, statsd_config.Cluster, status.Host)
+	prefix := statsd_config.Env
+	if len(statsd_config.Cluster) > 0 {
+		prefix = fmt.Sprintf("%s.%s", prefix, statsd_config.Cluster)
+	}
+	prefix = fmt.Sprintf("%s.%s", prefix, status.Host)
 	host_port := fmt.Sprintf("%s:%d", statsd_config.Host, statsd_config.Port)
 	client, err := statsd.NewClient(host_port, prefix)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func pushExtraInfo(client statsd.Statter, info ExtraInfo) error {
 }
 
 func pushStats(statsd_config Statsd, status ServerStatus) error {
-	prefix := fmt.Sprintf("statsd.mongodb.%s.%s.%s", statsd_config.Env, statsd_config.Cluster, status.Host)
+	prefix := fmt.Sprintf("%s.%s.%s", statsd_config.Env, statsd_config.Cluster, status.Host)
 	host_port := fmt.Sprintf("%s:%d", statsd_config.Host, statsd_config.Port)
 	client, err := statsd.NewClient(host_port, prefix)
 	if err != nil {


### PR DESCRIPTION
disclaimer: I should have broken this into multiple pull requests...  Sorry.

This pull provides:
- simplified build script (I'm sure there's a better way, I'm not super familiar with the go ecosystem)
- `-statsd_cluster` now accepts an empty string as an argument and doesn't build a bogus key if you do that
- `statsd_env` now acts as the entire key prefix instead of preceeding it with `stats....`
- added a few comments to the README to help a new user get started
