### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang
+
+ADD . /usr/src/mgo-statsd
+WORKDIR /usr/src/mgo-statsd
+
+RUN ./build.sh
+
+ENTRYPOINT [ "./mgo-statsd" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
By now, I use the official Golang image, default tag (minimalist 'alpine' lacks git). More info at https://hub.docker.com/_/golang/

Just adding files and running `build.sh`. Default option to `mgo-statsd` if none provided is `--help` to show usage. Default mongo_host `localhost` won't work, since nothing else apart from `mgo-statsd` runs inside the container, you have to look for the MongoDB elsewhere outside the container.

Build:

```
$ docker build -t mgo-statsd .
```

Run (assuming an already running MongoDB):

```
$ docker run -dit --name mgo-statsd mgo-statsd [optional parameters]
```

Optional improvement to come:
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process.
