### PR TITLE
Update Docker instructions to use official image on Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,14 @@ unauthorized fashion to a mongodb instance on localhost.
 
 ## Docker container
 
-Can be built from this repo using:
+Launch a container using the image on Docker Hub built from this source repo:
+```
+$ docker run -dit --name mgo-statsd scullxbones/mgo-statsd [optional parameters]
+```
 
+To build a local image from this repo using:
 ```
 $ docker build -t mgo-statsd .
-```
-
-Or can be pulled from docker hub via:
-```
-$ docker pull scullxbones/mgo-statsd
-```
-
-and run (assuming an already running MongoDB) using:
-```
-$ docker run -dit --name mgo-statsd mgo-statsd [optional parameters]
 ```
 
 


### PR DESCRIPTION
Instead of using the locally built image to run, use the Docker Hub official source image. Better focus in ease of run to allow less advanced users try it right away. This also states which is the official image and highlights that it is an automated build, which makes it more trusty.
Moved the Docker build instructions down, since it will be less common and targetting more advanced users/devs.
