### PR TITLE
Add Docker Compose development stack manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,17 @@ To build a local image from this repo using:
 $ docker build -t mgo-statsd .
 ```
 
+### Docker-based development stack using Docker Compose
 
+If you have both Docker and [Docker Compose](https://docs.docker.com/compose/) installed, you can launch a complete development stack with a single command by using the provided ```docker-compose.yml``` file.
+
+The stack defines the following containers:
+* A MongoDB 3.x service, with logging muted.
+* A StatsD service configured with console output backend, for debugging.
+* A mgo-statsd service linked to above services, built from source. See manifest for used command-line options.
+
+Start the stack by running:
+```
+$ docker-compose up
+```
+Stop it by ```CTRL+C```'ing it. See Docker Compose docs for help operating the stack.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+mongo:
+  image: mongo:3
+  log_driver: none
+
+mgo-statsd:
+  build: .
+  command: --mongo_address mongo -statsd_host statsd -interval 1s -statsd_env test -statsd_cluster test_mongo
+  links:
+    - mongo
+    - statsd
+
+statsd:
+  image: pataquets/statsd-debug


### PR DESCRIPTION
While attempting to take a stab at scullxbones/mgo-statsd#6, I created a manifest to launch a dev stack using Docker. It might come handy to anyone interested in hacking.
Unfortunately, my Go-jitsu is not strong enough :(