### PR TITLE
Allow mgo-statsd to be called as a go module also

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,4 @@ go_is_not_installed=`which go`
 dep ensure
 
 # now build it
-go build
+go build cmd/mgo-statsd.go

--- a/cmd/mgo-statsd.go
+++ b/cmd/mgo-statsd.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	mstatsd "github.com/scullxbones/mgo-statsd"
+)
+
+func main() {
+	config := mstatsd.LoadConfig()
+
+	quit := make(chan struct{})
+	for i, server := range config.Mongo.Addresses {
+		mgocnf := mstatsd.Mongo{
+			Addresses: []string{server},
+			User:      config.Mongo.User,
+			Pass:      config.Mongo.Pass,
+			AuthDb:    config.Mongo.AuthDb,
+		}
+		ticker := time.NewTicker(config.Interval)
+		go func(cnf mstatsd.Mongo, num int) {
+			for {
+				select {
+				case <-ticker.C:
+					if config.Verbose {
+						log.Printf("[%v] Starting stats for address %v \n", num, cnf.Addresses)
+					}
+					err := mstatsd.PushStats(config.Statsd, mstatsd.GetServerStatus(cnf), config.Verbose)
+					if err != nil {
+						log.Printf("[%v] ERROR: %v\n", num, err)
+					}
+					if config.Verbose {
+						log.Printf("[%v] Done pushing stats for address %v\n", num, cnf.Addresses)
+					}
+				case <-quit:
+					ticker.Stop()
+					return
+				}
+			}
+		}(mgocnf, i)
+	}
+	ch := make(chan os.Signal)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	sig := <-ch
+	log.Printf("Received signal [%s]", sig.String())
+	close(quit)
+}

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package main
+package mstatsd
 
 import (
 	"flag"


### PR DESCRIPTION
This PR allows mgo-statsd to be called from other go programs, as a module.

The main() func was moved to cmd/mgo-statsd.go to achieve this and build.sh is updated to build to the same location as before. This change seems to be backwards compatible as far as documentation/building.