### PR TITLE
Maintain db connection for lifetime of mgo-statsd, return a pointer in GetServerStatus

### DIFF
--- a/cmd/mgo-statsd.go
+++ b/cmd/mgo-statsd.go
@@ -19,7 +19,7 @@ func main() {
 		session, err := mstatsd.GetSession(config.Mongo, server)
 		if err != nil {
 			log.Printf("Error connecting to mongo %s: %v\n", server, err)
-			return
+			continue
 		}
 		defer session.Close()
 

--- a/cmd/mgo-statsd.go
+++ b/cmd/mgo-statsd.go
@@ -16,21 +16,9 @@ func main() {
 
 	quit := make(chan struct{})
 	for i, server := range config.Mongo.Addresses {
-		dialInfo := mgo.DialInfo{
-			Addrs:   []string{server},
-			Direct:  true,
-			Timeout: time.Second * 5,
-		}
-
-		if len(config.Mongo.User) > 0 {
-			dialInfo.Username = config.Mongo.User
-			dialInfo.Password = config.Mongo.Pass
-			dialInfo.Source = config.Mongo.AuthDb
-		}
-
-		session, err := mgo.DialWithInfo(&dialInfo)
+		session, err := mstatsd.GetSession(config.Mongo, server)
 		if err != nil {
-			log.Printf("Error connecting to mongo %v: %v\n", dialInfo, err)
+			log.Printf("Error connecting to mongo %s: %v\n", server, err)
 			return
 		}
 		defer session.Close()

--- a/cmd/mgo-statsd.go
+++ b/cmd/mgo-statsd.go
@@ -36,7 +36,7 @@ func main() {
 		defer session.Close()
 
 		ticker := time.NewTicker(config.Interval)
-		go func(server string, num int) {
+		go func(session *mgo.Session, server string, num int) {
 			for {
 				select {
 				case <-ticker.C:
@@ -55,7 +55,7 @@ func main() {
 					return
 				}
 			}
-		}(server, i)
+		}(session, server, i)
 	}
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/mgo-statsd.go
+++ b/mgo-statsd.go
@@ -118,15 +118,21 @@ func GetSession(mongoConfig Mongo, server string) (*mgo.Session, error) {
 		dialInfo.Password = mongoConfig.Pass
 		dialInfo.Source = mongoConfig.AuthDb
 	}
-	return mgo.DialWithInfo(&dialInfo)
+	session, err := mgo.DialWithInfo(&dialInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional. Switch the session to a monotonic behavior.
+	session.SetMode(mgo.Monotonic, true)
+
+	return session, nil
 }
 
 func GetServerStatus(session *mgo.Session) *ServerStatus {
 	if session == nil {
 		return nil
 	}
-	// Optional. Switch the session to a monotonic behavior.
-	session.SetMode(mgo.Monotonic, true)
 
 	var s *ServerStatus
 	if err := session.Run("serverStatus", &s); err != nil {

--- a/mgo-statsd.go
+++ b/mgo-statsd.go
@@ -114,7 +114,7 @@ func GetServerStatus(session *mgo.Session) *ServerStatus {
 	session.SetMode(mgo.Monotonic, true)
 
 	var s *ServerStatus
-	if err := session.Run("serverStatus", &s); err != nil {
+	if err := session.Run("serverStatus", s); err != nil {
 		log.Printf("Error running 'serverStatus' command: %v\n", err)
 		return s
 	}

--- a/mgo-statsd.go
+++ b/mgo-statsd.go
@@ -107,6 +107,7 @@ type ServerStatus struct {
 	WiredTiger           *WiredTigerInfo     `metric:"wiredTiger"`
 }
 
+// GetSession creates and configures a new mgo.Session
 func GetSession(mongoConfig Mongo, server string) (*mgo.Session, error) {
 	dialInfo := mgo.DialInfo{
 		Addrs:   []string{server},
@@ -129,6 +130,7 @@ func GetSession(mongoConfig Mongo, server string) (*mgo.Session, error) {
 	return session, nil
 }
 
+// GetServerStatus returns a struct of the MongoDB 'serverStatus' command response
 func GetServerStatus(session *mgo.Session) *ServerStatus {
 	if session == nil {
 		return nil

--- a/mgo-statsd.go
+++ b/mgo-statsd.go
@@ -114,7 +114,7 @@ func GetServerStatus(session *mgo.Session) *ServerStatus {
 	session.SetMode(mgo.Monotonic, true)
 
 	var s *ServerStatus
-	if err := session.Run("serverStatus", s); err != nil {
+	if err := session.Run("serverStatus", &s); err != nil {
 		log.Printf("Error running 'serverStatus' command: %v\n", err)
 		return s
 	}

--- a/mgo-statsd.go
+++ b/mgo-statsd.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	str "strings"
+	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/kr/pretty"
@@ -104,6 +105,20 @@ type ServerStatus struct {
 	ReplicaSet           ReplicaInfo         `metric:"repl"`
 	Metrics              ServerMetrics       `metric:"metrics"`
 	WiredTiger           *WiredTigerInfo     `metric:"wiredTiger"`
+}
+
+func GetSession(mongoConfig Mongo, server string) (*mgo.Session, error) {
+	dialInfo := mgo.DialInfo{
+		Addrs:   []string{server},
+		Direct:  true,
+		Timeout: time.Second * 5,
+	}
+	if len(mongoConfig.User) > 0 {
+		dialInfo.Username = mongoConfig.User
+		dialInfo.Password = mongoConfig.Pass
+		dialInfo.Source = mongoConfig.AuthDb
+	}
+	return mgo.DialWithInfo(&dialInfo)
 }
 
 func GetServerStatus(session *mgo.Session) *ServerStatus {


### PR DESCRIPTION
This PR moves to maintaining a single database connection for the lifetime of mgo-statsd, instead of open/closing the database connection each polling. This reduces log noise in mongod *(each mgo-statsd poll causes a connect+disconnect message)* and reduces connection CPU overhead from TCP handshakes.

On installs with SSL mode 'preferSSL' you actually get 3 x log lines per mgo-statsd polling before this change (2 x log lines without ssl):

```
2018-04-26T11:56:55.658+0000 I NETWORK  [conn56] SSL mode is set to 'preferred' and connection 56 to 127.0.0.1:57226 is not using SSL.
2018-04-26T11:56:55.669+0000 I ACCESS   [conn56] Successfully authenticated as principal admin on admin
2018-04-26T11:56:55.672+0000 I -        [conn56] end connection 127.0.0.1:57226 (1 connection now open)
```
After this change there is only a connection logged at startup and shutdown of mgo-statsd. The session also auto-reconnects on failure, due to built-in functionality in mgo.v2.

This fix required making .GetServerStatus() take-in a *mgo.Session instead of a Mongo struct. I also removed the commented-out .Login() logic that is handled internally by mgo.

Lastly, I made .GetServerStatus() return a pointer to *ServerStatus so checks like this:
https://github.com/scullxbones/mgo-statsd/blob/cd30ad2ce08d42da38ab9c54ebc672bb1769d02c/mgo-statsd.go#L409-L411

Can become an if-nil check like this:
```
 if status == nil { 
 	return nil // This means we didn't connect, so lets silently skip this cycle 
 } 
```
This change ^^^ also helps with the code I am integrating with mgo-statsd.

This should be the last of my improvements/suggestions for now! Thanks